### PR TITLE
null certifiers bug fix

### DIFF
--- a/src/authrite.js
+++ b/src/authrite.js
@@ -185,7 +185,7 @@ class Authrite {
     this.servers[baseUrl].nonce = serverResponse.nonce
 
     // Check certificates were requested, and that the client is using Babbage as the signing strategy
-    if (serverResponse.requestedCertificates.certifiers.length !== 0 && this.signingStrategy === 'Babbage') {
+    if (serverResponse.requestedCertificates.certifiers && serverResponse.requestedCertificates.certifiers.length !== 0 && this.signingStrategy === 'Babbage') {
       // Find matching certificates
       let matchingCertificates = await BabbageSDK.getCertificates({
         certifiers: serverResponse.requestedCertificates.certifiers,


### PR DESCRIPTION
When there are no certificates requested, BabbageDesktop is currently failing when I try to run it locally (using docker).
This one line in authrite-js appears to be the problem.